### PR TITLE
kernel: Create kernel thread

### DIFF
--- a/kthreads/Makefile
+++ b/kthreads/Makefile
@@ -1,0 +1,7 @@
+#export CC=x86_64-linux-gnu-gcc-13
+obj-m += kthreads.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/kthreads/kthreads.c
+++ b/kthreads/kthreads.c
@@ -1,0 +1,70 @@
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/kthread.h>	// threads related functions
+#include <linux/sched.h>	// task structs
+#include <linux/delay.h>	// delays
+
+#define dev_print(fmt, ...)	printk(KERN_DEFAULT "Mausam[%s:%d] : " fmt, __func__, __LINE__, ##__VA_ARGS__)
+
+struct task_struct *kthread_1;
+struct task_struct *kthread_2;
+int thread_1 = 1;
+int thread_2 = 2;
+
+//Declarations
+int kern_thread (void *args);
+
+int kern_thread (void *args) {
+	int counter = 0;
+	int thread_nr = *(int *) args;
+
+	while(kthread_should_stop() == 0) {
+		dev_print("Executing the %d thread, counter value : %d\n", thread_nr, counter++);
+		msleep(thread_nr * 1000);
+	}
+	
+	dev_print("Thread %d is exiting\n", thread_nr);
+	return 0;
+}
+
+static int __init kthread_init(void) {
+	dev_print("Creating threads\n");
+	
+	// kthread_create() : Creates Kernel thread but don't start its execution
+	kthread_1 = kthread_create(kern_thread, &thread_1, "Kernel_Thread_1");
+	if(kthread_1 != NULL) {
+		dev_print("Thread 1 with PID : %d is created\n", kthread_1->pid);
+		wake_up_process(kthread_1);	// Wake up kthread_1
+	} else {
+		dev_print("Thread 1 creation fails\n");
+		goto label;
+	}
+
+	//khread_run() : Creates kernel thread and start its execution
+	kthread_2 = kthread_run(kern_thread, &thread_2, "Kernel_Thread_2");
+	if(kthread_2 != NULL) {
+		dev_print("Thread 2 with PID : %d is created and running\n", kthread_2->pid);
+	} else {
+		dev_print("Thread 2 creation fails\n");
+		kthread_stop(kthread_1);	// Send signal to first thread to stop its execution
+	}
+
+	dev_print("Thread creation DONE !!\n");
+label:	
+	return 0;
+}
+
+static void __exit kthread_exitt(void) {
+	kthread_stop(kthread_1);
+	kthread_stop(kthread_2);
+	dev_print("Module exit\n");
+	return;
+}
+
+module_init(kthread_init);	
+module_exit(kthread_exitt);
+
+MODULE_AUTHOR("Mausam");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Simple kernel threads program");


### PR DESCRIPTION
[62502.713411] Mausam[kthread_init:33] : Creating threads
[62502.713461] Mausam[kthread_init:37] : Thread 1 with PID : 30543 is created
[62502.713466] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 0
[62502.713480] Mausam[kthread_init:46] : Thread 2 with PID : 30544 is created and running
[62502.713482] Mausam[kern_thread:24] : Executing the 2 thread, counter value : 0
[62502.713482] Mausam[kthread_init:52] : Thread creation DONE !!
[62503.759222] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 1
[62504.719405] Mausam[kern_thread:24] : Executing the 2 thread, counter value : 1
[62504.784251] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 2
[62505.807584] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 3
[62506.767395] Mausam[kern_thread:24] : Executing the 2 thread, counter value : 2
[62506.831424] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 4
[62507.855564] Mausam[kern_thread:24] : Executing the 1 thread, counter value : 5
[62508.815694] Mausam[kern_thread:24] : Executing the 2 thread, counter value : 3
[62516.047917] Mausam[kern_thread:28] : Thread 1 is exiting
[62517.007657] Mausam[kern_thread:28] : Thread 2 is exiting
[62517.007733] Mausam[kthread_exitt:60] : Module exit

Signed-off-by : Mausam Yadav